### PR TITLE
Fixed incorrect consideration of certain ACF lag values as period candidates

### DIFF
--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -41,11 +41,11 @@ def test_find_strongest_period_var_wise_stl_custom():
     strongest_period_var = period_finder.fit_find_strongest_var(
         decomposer=Decomposer.STL, decomposer_kwargs={"seasonal_deg": 0}
     )
-    assert strongest_period_var == 132
+    assert strongest_period_var == 180
 
 
 def test_find_strongest_period_var_wise_moving_averages():
     data = co2.load().data.resample("M").mean().ffill()
     period_finder = AutoPeriodFinder(data)
     strongest_period_var = period_finder.fit_find_strongest_var()
-    assert strongest_period_var == 132
+    assert strongest_period_var == 176


### PR DESCRIPTION
Fixed handling acf_arr so that incorrect periods that are adjacent to correct ones are no longer considered just because the latter's ACF coefficient was set to -1 after verification