### PR TITLE
Technical Debt - Modernize Type Hints

### DIFF
--- a/pyriodicity/_internal/online_helper.py
+++ b/pyriodicity/_internal/online_helper.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Union
+from typing import Literal
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -56,9 +56,9 @@ class OnlineHelper:
     def __init__(
         self,
         window_size: int,
-        buffer_size: Optional[int] = None,
-        window_func: Union[str, float, tuple] = "boxcar",
-        detrend_func: Optional[Literal["constant", "linear"]] = "linear",
+        buffer_size: int | None = None,
+        window_func: str | float | tuple = "boxcar",
+        detrend_func: Literal["constant", "linear"] | None = "linear",
     ):
         # Initialize size attributes
         self.window_size = window_size
@@ -96,7 +96,7 @@ class OnlineHelper:
 
     def update(
         self,
-        data: Union[np.floating, ArrayLike],
+        data: np.floating | ArrayLike,
         return_value: Literal["rfft", "acf"] = "rfft",
     ) -> NDArray:
         """

--- a/pyriodicity/_internal/utils.py
+++ b/pyriodicity/_internal/utils.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Union
+from typing import Literal
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -33,7 +33,7 @@ def to_1d_array(x: ArrayLike) -> NDArray:
 
 
 @staticmethod
-def apply_window(x: ArrayLike, window_func: Union[str, float, tuple]) -> NDArray:
+def apply_window(x: ArrayLike, window_func: str | float | tuple) -> NDArray:
     """
     Apply a window function to the input array.
 
@@ -92,8 +92,8 @@ def power_threshold(
     x: ArrayLike,
     k: int,
     p: int,
-    window_func: Union[str, tuple, ArrayLike] = "boxcar",
-    detrend_func: Optional[Literal["constant", "linear"]] = "linear",
+    window_func: str | tuple | ArrayLike = "boxcar",
+    detrend_func: Literal["constant", "linear"] | None = "linear",
 ) -> np.floating:
     """
     Compute the power threshold as the p-th percentile of the maximum

--- a/pyriodicity/online/online_acf.py
+++ b/pyriodicity/online/online_acf.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Union
+from typing import Literal
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -43,9 +43,9 @@ class OnlineACFPeriodicityDetector:
     def __init__(
         self,
         window_size: int,
-        buffer_size: Optional[int] = None,
-        window_func: Union[float, str, tuple] = "boxcar",
-        detrend_func: Optional[Literal["constant", "linear"]] = "linear",
+        buffer_size: int | None = None,
+        window_func: float | str | tuple = "boxcar",
+        detrend_func: Literal["constant", "linear"] | None = "linear",
     ):
         self.window_size = window_size
         self.online_helper = OnlineHelper(
@@ -54,8 +54,8 @@ class OnlineACFPeriodicityDetector:
 
     def detect(
         self,
-        data: Union[np.floating, ArrayLike],
-        max_period_count: Optional[int] = None,
+        data: np.floating | ArrayLike,
+        max_period_count: int | None = None,
     ) -> NDArray:
         """
         Update the online ACF and detect periodicities.

--- a/pyriodicity/online/online_fft.py
+++ b/pyriodicity/online/online_fft.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Union
+from typing import Literal
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -41,9 +41,9 @@ class OnlineFFTPeriodicityDetector:
     def __init__(
         self,
         window_size: int,
-        buffer_size: Optional[int] = None,
-        window_func: Union[float, str, tuple] = "boxcar",
-        detrend_func: Optional[Literal["constant", "linear"]] = "linear",
+        buffer_size: int | None = None,
+        window_func: float | str | tuple = "boxcar",
+        detrend_func: Literal["constant", "linear"] | None = "linear",
     ):
         # Initialize the online helper
         self.online_helper = OnlineHelper(
@@ -60,8 +60,8 @@ class OnlineFFTPeriodicityDetector:
 
     def detect(
         self,
-        data: Union[np.floating, ArrayLike],
-        max_period_count: Optional[int] = None,
+        data: np.floating | ArrayLike,
+        max_period_count: int | None = None,
     ) -> NDArray:
         """
         Update the frequency spectrum and detect periodicities.

--- a/pyriodicity/static/acf.py
+++ b/pyriodicity/static/acf.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Union
+from typing import Literal
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -54,9 +54,9 @@ class ACFPeriodicityDetector:
     @staticmethod
     def detect(
         data: ArrayLike,
-        window_func: Union[str, float, tuple] = "boxcar",
-        detrend_func: Optional[Literal["constant", "linear"]] = "linear",
-        max_period_count: Optional[int] = None,
+        window_func: str | float | tuple = "boxcar",
+        detrend_func: Literal["constant", "linear"] | None = "linear",
+        max_period_count: int | None = None,
     ) -> NDArray:
         """
         Find periods in the given series.

--- a/pyriodicity/static/autoperiod.py
+++ b/pyriodicity/static/autoperiod.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Union
+from typing import Literal
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -63,8 +63,8 @@ class Autoperiod:
         data: ArrayLike,
         k: int = 100,
         percentile: int = 95,
-        window_func: Union[str, float, tuple] = "boxcar",
-        detrend_func: Optional[Literal["constant", "linear"]] = "linear",
+        window_func: str | float | tuple = "boxcar",
+        detrend_func: Literal["constant", "linear"] | None = "linear",
     ) -> NDArray:
         """
         Find periods in the given series.

--- a/pyriodicity/static/cfd_autoperiod.py
+++ b/pyriodicity/static/cfd_autoperiod.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Union
+from typing import Literal
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -64,8 +64,8 @@ class CFDAutoperiod:
         data: ArrayLike,
         k: int = 100,
         percentile: int = 99,
-        detrend_func: Optional[Literal["constant", "linear"]] = "linear",
-        window_func: Optional[Union[str, float, tuple]] = None,
+        detrend_func: Literal["constant", "linear"] | None = "linear",
+        window_func: str | float | tuple | None = None,
     ) -> NDArray:
         """
         Find periods in the given series.

--- a/pyriodicity/static/fft.py
+++ b/pyriodicity/static/fft.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Union
+from typing import Literal
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -60,9 +60,9 @@ class FFTPeriodicityDetector:
     @staticmethod
     def detect(
         data: ArrayLike,
-        window_func: Union[float, str, tuple] = "boxcar",
-        detrend_func: Optional[Literal["constant", "linear"]] = "linear",
-        max_period_count: Optional[int] = None,
+        window_func: float | str | tuple = "boxcar",
+        detrend_func: Literal["constant", "linear"] | None = "linear",
+        max_period_count: int | None = None,
     ) -> NDArray:
         """
         Find periods in the given series.

--- a/pyriodicity/static/robustperiod.py
+++ b/pyriodicity/static/robustperiod.py
@@ -3,7 +3,7 @@ from concurrent.futures import ProcessPoolExecutor
 from enum import Enum, unique
 from functools import partial
 from multiprocessing import cpu_count
-from typing import Literal, Optional, Tuple, Union
+from typing import Literal
 
 import numpy as np
 import pywt
@@ -153,13 +153,13 @@ class RobustPeriod:
     @staticmethod
     def detect(
         data: ArrayLike,
-        lamb: Union[float, Literal["hodrick-prescott", "ravn-uhlig"]] = "ravn-uhlig",
+        lamb: float | Literal["hodrick-prescott", "ravn-uhlig"] = "ravn-uhlig",
         c: float = 1.5,
         db_n: int = 8,
         modwt_level: int = 10,
         delta: float = 1.345,
-        max_worker_count: Optional[int] = None,
-        max_period_count: Optional[int] = None,
+        max_worker_count: int | None = None,
+        max_period_count: int | None = None,
     ) -> NDArray:
         """
         Find periods in the given series.
@@ -249,9 +249,7 @@ class RobustPeriod:
         )
 
     @staticmethod
-    def _preprocess(
-        x: ArrayLike, lamb: Union[float, _LambdaSelection], c: float
-    ) -> NDArray:
+    def _preprocess(x: ArrayLike, lamb: float | _LambdaSelection, c: float) -> NDArray:
         """
         Apply the data preprocessing step of RobustPeriod.
 
@@ -274,7 +272,7 @@ class RobustPeriod:
             Preprocessed data.
         """
 
-        def hpfilter(x: NDArray, lamb: float) -> Tuple:
+        def hpfilter(x: NDArray, lamb: float) -> tuple:
             """
             Apply the Hodrick-Prescott filter to a series.
 
@@ -516,7 +514,7 @@ class RobustPeriod:
                 np.nan_to_num(binom(n, k)) * np.nan_to_num((1 - k * g0) ** (n - 1))
             )
 
-        def get_period(periodogram: NDArray) -> Optional[int]:
+        def get_period(periodogram: NDArray) -> int | None:
             """
             Determine the period of a given periodogram.
 

--- a/pyriodicity/static/sazed.py
+++ b/pyriodicity/static/sazed.py
@@ -1,5 +1,5 @@
 from collections import Counter
-from typing import Literal, Optional, Union
+from typing import Literal
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -54,10 +54,10 @@ class SAZED:
     @staticmethod
     def detect(
         data: ArrayLike,
-        window_func: Union[str, float, tuple] = "boxcar",
-        detrend_func: Optional[Literal["constant", "linear"]] = "linear",
+        window_func: str | float | tuple = "boxcar",
+        detrend_func: Literal["constant", "linear"] | None = "linear",
         method: Literal["optimal", "majority"] = "optimal",
-    ) -> Optional[int]:
+    ) -> int | None:
         """
         Detect a period in the input data using the SAZED ensemble method.
 
@@ -97,7 +97,7 @@ class SAZED:
             - If method is neither 'optimal' nor 'majority'
         """
 
-        def s(data: NDArray) -> Optional[int]:
+        def s(data: NDArray) -> int | None:
             """
             Spectral component of SAZED (S).
 
@@ -108,7 +108,7 @@ class SAZED:
 
             Returns
             -------
-            Optional[int]
+            int | None
                 The detected period length in samples, or None if no valid period
                 is found.
             """
@@ -130,7 +130,7 @@ class SAZED:
                 return None
             return periods[np.argmax(psd)]
 
-        def ze(data: NDArray) -> Optional[int]:
+        def ze(data: NDArray) -> int | None:
             """
             Zero-crossing mean component (ZE).
 
@@ -141,7 +141,7 @@ class SAZED:
 
             Returns
             -------
-            Optional[int]
+            int | None
                 The detected period length in samples based on mean zero-crossing
                 distance, or None if no valid period is found.
             """
@@ -163,7 +163,7 @@ class SAZED:
                 else np.rint(np.mean(distances)).astype(int) * 2
             )
 
-        def zed(data: NDArray) -> Optional[int]:
+        def zed(data: NDArray) -> int | None:
             """
             Zero-crossing Density component (ZED).
 
@@ -174,7 +174,7 @@ class SAZED:
 
             Returns
             -------
-            Optional[int]
+            int | None
                 The detected period length in samples based on zero-crossing
                 density estimation, or None if no valid period is found.
 


### PR DESCRIPTION
Replace the deprecated `Union`, `Option`, and `Tuple` with their modern alternatives.